### PR TITLE
(#158) Use System.Close instead of System.CPUTime

### DIFF
--- a/HyperNerd.cabal
+++ b/HyperNerd.cabal
@@ -82,6 +82,7 @@ executable HyperNerd
                      , async
                      , base >=4.9 && <4.10
                      , bytestring
+                     , clock
                      , containers
                      , exceptions
                      , file-embed


### PR DESCRIPTION
Close #158 