### PR TITLE
Improvements to Dockerfile and build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,19 @@
+### General ###
+.git
+.gitignore
+.dockerignore
+.hindent.yaml
+.hlint.yaml
+.snitch.yaml
+.travis.yaml
+doc
+scripts
+test
+*.md
+*.nix
+
 ### Haskell ###
+.dir-local.el
 dist
 dist-*
 cabal-dev
@@ -21,7 +36,6 @@ cabal.project.local
 .HTF/
 
 ### HyperNerd ###
-
 *.ini
 *.db
 *.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,6 @@ RUN \
 COPY --from=builder /build/dist/build/HyperNerd/HyperNerd /app
 WORKDIR /app
 
+# TODO: Use `ENTRYPOINT` instead and instead pass arguments;  This won't work with the current setup.  Also
+# `/tmp` is not idiomatic directory; use /data or (FHS compliant)
 CMD ["/app/HyperNerd", "/tmp/hypernerd/secret.ini", "/tmp/hypernerd/database.db",  "/tmp/hypernerd/markov.csv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,12 +31,6 @@ RUN \
 COPY . /build/
 RUN \
   cabal build exe:HyperNerd
-
-# Install necessary dependencies and build HyperNerd
-# NOTE: happy package provides an executable that is needed to build
-# qm-interpolated-string package. qm-interpolated-string does not
-# depend on happy for some reason and that's why we have to install it
-# separately.
 ################################################################################
 # Application                                                                  #
 ################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,45 @@
-FROM alpine:3.9
+################################################################################
+# Builder                                                                      #
+################################################################################
+FROM alpine:3.9 as builder
 
 MAINTAINER Alexey Kutepov <reximkut@gmail.com>
 
-VOLUME ["/tmp/hypernerd"]
+# Have base OS package installation in a single layer
+RUN \
+  apk update && \
+  apk add --no-cache \
+    openssl-dev curl ghc cabal \
+    gmp-dev build-base zlib-dev && \
+  cabal update && \
+  mkdir -p /build/
 
-RUN apk add --no-cache openssl-dev
-RUN apk add --no-cache curl
-RUN apk add --no-cache ghc
-RUN apk add --no-cache cabal
-RUN apk add --no-cache gmp-dev
-RUN apk add --no-cache build-base
-RUN apk add --no-cache zlib-dev
+WORKDIR /build/
+COPY . /build/
 
-RUN cabal update
-RUN mkdir /hypernerd/
-COPY ./HyperNerd.cabal /hypernerd/
-COPY ./Setup.hs /hypernerd/
-WORKDIR /hypernerd/
-RUN cabal sandbox init
+# Install necessary dependencies and build HyperNerd
 # NOTE: happy package provides an executable that is needed to build
 # qm-interpolated-string package. qm-interpolated-string does not
 # depend on happy for some reason and that's why we have to install it
 # separately.
-RUN cabal install happy-1.19.9
-RUN cabal install --only-dependencies
-COPY ./resources/ /hypernerd/resources/
-COPY ./src/ /hypernerd/src/
-RUN cabal build exe:HyperNerd
+RUN \
+  cabal install happy-1.19.9 && \
+  cabal install -j4 --only-dependencies && \
+  cabal build exe:HyperNerd
 
-CMD ["/hypernerd/dist/build/HyperNerd/HyperNerd", "/tmp/hypernerd/secret.ini", "/tmp/hypernerd/database.db", "/tmp/hypernerd/markov.csv"]
+
+################################################################################
+# Application                                                                  #
+################################################################################
+FROM alpine:3.9 AS app
+
+RUN \
+  apk update && \
+  apk add --no-cache \
+    gmp libffi zlib openssl curl && \
+  mkdir -p /app
+
+COPY --from=builder /build/dist/build/HyperNerd/HyperNerd /app
+WORKDIR /app
+
+CMD ["/app/HyperNerd", "/tmp/hypernerd/secret.ini", "/tmp/hypernerd/database.db",  "/tmp/hypernerd/markov.csv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,19 +15,28 @@ RUN \
   mkdir -p /build/
 
 WORKDIR /build/
+
+# Copy over files and create a dependency installation layer
+# NOTE: happy package provides an executable that is needed to build
+# qm-interpolated-string package. qm-interpolated-string does not
+# depend on happy for some reason and that's why we have to install it
+# separately.
+COPY HyperNerd.cabal Setup.hs /build/
+RUN \
+  cabal sandbox init && \
+  cabal install happy-1.19.9 && \
+  cabal install --only-dependencies
+
+# Finally, copy source directories and build executable
 COPY . /build/
+RUN \
+  cabal build exe:HyperNerd
 
 # Install necessary dependencies and build HyperNerd
 # NOTE: happy package provides an executable that is needed to build
 # qm-interpolated-string package. qm-interpolated-string does not
 # depend on happy for some reason and that's why we have to install it
 # separately.
-RUN \
-  cabal install happy-1.19.9 && \
-  cabal install -j4 --only-dependencies && \
-  cabal build exe:HyperNerd
-
-
 ################################################################################
 # Application                                                                  #
 ################################################################################
@@ -42,6 +51,6 @@ RUN \
 COPY --from=builder /build/dist/build/HyperNerd/HyperNerd /app
 WORKDIR /app
 
-# TODO: Use `ENTRYPOINT` instead and instead pass arguments;  This won't work with the current setup.  Also
-# `/tmp` is not idiomatic directory; use /data or (FHS compliant)
+# TODO: Use `ENTRYPOINT` instead and instead pass arguments
+# This won't work with the current setup.  Also `/tmp` is not a idiomatic directory; use /data or (FHS compliant)
 CMD ["/app/HyperNerd", "/tmp/hypernerd/secret.ini", "/tmp/hypernerd/database.db",  "/tmp/hypernerd/markov.csv"]

--- a/README.md
+++ b/README.md
@@ -94,10 +94,17 @@ TBD
 
 <!-- TODO(#478): Debug mode is not documented -->
 
+## Docker-Compose
+With secrets existing in volume defined in `docker-compose.yaml`,
+```console
+$ docker-compose up --build
+```
+
+
 ## Docker
 
 ```console
-$ docker build -t hypernerd .
+$ docker build --target app -t hypernerd .
 $ mkdir hypernerd-state
 $ cp secret.ini hypernerd-state
 $ docker create -v /absolute/path/to/hypernerd-state/:/tmp/hypernerd/ \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3.6'
+
+services:
+  hypernerd:
+    image: hypernerd
+    build:
+      context: .
+      target: app
+    volumes:
+      - ./hypernerd-state/:/tmp/hypernerd/


### PR DESCRIPTION
Improvements are made to the Dockerfile.  In addition to reducing the number of layers, the Dockerfile was modified into a multi-stage build in which the built executable is copied into the final container.  This has led to a vast size difference between the original build and the application docker image (~2.1GB to ~63MB)!

Additionally, a `docker-compose` file was added as both an example and an easier way to run the software locally and the documentation changed to reflect this.

NOTE:  While this was tested and runs for IRC, I do not have a Discord bot/credentials.  It will *presumably* run the same.