### PR TITLE
bump time library to 1.9.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages: .
 
-allow-newer:  base, time, network, socks, connection
+allow-newer: time
 
 constraints: time >= 1.9.2

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages: .
+
+allow-newer:  base, time, network, socks, connection
+
+constraints: time >= 1.9.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,9 +43,7 @@ extra-deps:
 - hookup-0.2.2
 - irc-core-2.5.0
 - discord-haskell-0.7.1
-# use time-1.9.2 from github
-- github: haskell/time
-  commit: 9e96c26132fef01a3113c8b152b1be96c0eccd86
+- time-1.9.2
 
 # relax contraints at HyperNerd.cabal
 allow-newer: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,6 +43,12 @@ extra-deps:
 - hookup-0.2.2
 - irc-core-2.5.0
 - discord-haskell-0.7.1
+# use time-1.9.2 from github
+- github: haskell/time
+  commit: 9e96c26132fef01a3113c8b152b1be96c0eccd86
+
+# relax contraints at HyperNerd.cabal
+allow-newer: true
 
 # Override default flag values for local packages and extra-deps
 


### PR DESCRIPTION

No CI build.  but it compiles and tested locally on my computer.

I have to update base, network, hs-socks, hs-connection library to use latest time library.