### PR TITLE
Pin nixpkgs, and various libraries to allow a reproducibele shell

### DIFF
--- a/discord-haskell.nix
+++ b/discord-haskell.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, aeson, async, base, base64-bytestring, bytestring
+, containers, data-default, emoji, fetchgit, http-client
+, iso8601-time, JuicyPixels, MonadRandom, req, safe-exceptions
+, stdenv, text, time, unordered-containers, vector, websockets
+, wuss
+}:
+mkDerivation {
+  pname = "discord-haskell";
+  version = "0.8.3";
+  src = fetchgit {
+    url = "https://github.com/aquarial/discord-haskell";
+    sha256 = "0q3wq3shxnnr1xyk9y60hmfmyy5n47zdvjx63aq227hdgni5hin3";
+    rev = "6bd79875aaaef94d406d5281dfd92a358c91e88c";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson async base base64-bytestring bytestring containers
+    data-default emoji http-client iso8601-time JuicyPixels MonadRandom
+    req safe-exceptions text time unordered-containers vector
+    websockets wuss
+  ];
+  executableHaskellDepends = [ base text ];
+  homepage = "https://github.com/aquarial/discord-haskell";
+  description = "Write bots for Discord in Haskell";
+  license = stdenv.lib.licenses.mit;
+}

--- a/hypernerd.nix
+++ b/hypernerd.nix
@@ -1,0 +1,32 @@
+{ mkDerivation, aeson, array, async, base, bytestring, cassava
+, clock, containers, discord-haskell, exceptions, hookup
+, http-conduit, http-types, HUnit, ini, irc-core, JuicyPixels
+, louis, network, qm-interpolated-string, random, raw-strings-qq
+, regex-base, regex-tdfa, safe, sqlite-simple, stdenv, stm
+, template-haskell, temporary, text, time, transformers
+, unordered-containers, uri-encode, vector
+}:
+mkDerivation {
+  pname = "HyperNerd";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    aeson array async base bytestring cassava clock containers
+    discord-haskell exceptions hookup http-conduit http-types ini
+    irc-core JuicyPixels louis network qm-interpolated-string random
+    raw-strings-qq regex-base regex-tdfa safe sqlite-simple stm
+    template-haskell text time transformers unordered-containers
+    uri-encode vector
+  ];
+  testHaskellDepends = [
+    aeson array async base bytestring containers discord-haskell
+    exceptions http-conduit http-types HUnit qm-interpolated-string
+    raw-strings-qq regex-base regex-tdfa safe sqlite-simple stm
+    temporary text time transformers unordered-containers uri-encode
+  ];
+  homepage = "https://github.com/tsoding/HyperNerd";
+  description = "Twitch bot for Tsoding streams";
+  license = stdenv.lib.licenses.mit;
+}

--- a/louis.nix
+++ b/louis.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, bytestring, fetchgit, JuicyPixels, stdenv
+, text, vector
+}:
+mkDerivation {
+  pname = "louis";
+  version = "0.1.0.2";
+  src = fetchgit {
+    url = "https://github.com/tsoding/louis";
+    sha256 = "1h29b5kbdlv2if1v4hj1s6pr8qfi191w3vy4hicwi0if8m88di2z";
+    rev = "bc6b810161cc461a9e3ad0bb360f90440a07f3c6";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    base bytestring JuicyPixels text vector
+  ];
+  description = "Turning images into text using Braille font";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pin-unstable.nix
+++ b/pin-unstable.nix
@@ -1,0 +1,10 @@
+# this allows caching of instability.
+# making switches less annoying but also less up to date
+import (
+    builtins.fetchGit (
+    {
+        url = "https://github.com/NixOS/nixpkgs";
+        ref = "master";
+        rev = "12d815161abd4554482fc6dcad2443391c07667b";
+    }
+    ))

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{ nixpkgs ? import ./pin-unstable.nix {}, compiler ? "default", doBenchmark ? false }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage ./hypernerd.nix {
+  	discord-haskell = haskellPackages.callPackage ./discord-haskell.nix { };
+  	louis = haskellPackages.callPackage ./louis.nix { };
+  });
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv


### PR DESCRIPTION
in the default.nix import <nixpkgs> { } is used,
this uses the [host os'es nixpkgs](https://vaibhavsagar.com/blog/2018/05/27/quick-easy-nixpkgs-pinning/) rather than selecting a specific
one.
In my case this  would pull in various erronious libraries. It also couldn't find louis or discord-haskell so I also added those.
Pinning this down should make the libraries the same for anyone using this.

Most of this code is generated by cabal2nix, I just hooked it together and played with revisions untill I got a working build.

Cheers.
\- jappiejappie.