### PR TITLE
Replace hardcoded channel with configured channel in link filters

### DIFF
--- a/src/Bot.hs
+++ b/src/Bot.hs
@@ -63,7 +63,6 @@ import Transport
 
 type Bot = InEvent -> Effect ()
 
-
 builtinCommands :: ChannelName -> CommandTable
 builtinCommands channel =
   M.fromList
@@ -113,7 +112,9 @@ builtinCommands channel =
             cmapR (const ()) updateBttvEmotesCommand))
     , ( "help"
       , mkBuiltinCommand
-          ("Send help", $githubLinkLocationStr, helpCommand $ builtinCommands channel))
+          ( "Send help"
+          , $githubLinkLocationStr
+          , helpCommand $ builtinCommands channel))
     , ( "poll"
       , mkBuiltinCommand
           ( "Starts a poll. !poll <duration:secs> option1; option2; ...; option3"
@@ -225,13 +226,15 @@ builtinCommands channel =
           , authorizeSender senderAuthority $
             replyOnNothing "Only for mods" $
             regexArgs "([a-zA-Z0-9]+) ?(.*)" $
-            replyLeft $ pairArgs $ replyLeft $ addCustomCommand $ builtinCommands channel ))
+            replyLeft $
+            pairArgs $ replyLeft $ addCustomCommand $ builtinCommands channel))
     , ( "delcmd"
       , mkBuiltinCommand
           ( "Delete custom command"
           , $githubLinkLocationStr
           , authorizeSender senderAuthority $
-            replyOnNothing "Only for mods" $ deleteCustomCommand $ builtinCommands channel))
+            replyOnNothing "Only for mods" $
+            deleteCustomCommand $ builtinCommands channel))
     , ( "updcmd"
       , mkBuiltinCommand
           ( "Update custom command"
@@ -514,8 +517,8 @@ builtinCommands channel =
                    https://twitch.tv/{channel'}/subscribe|]
               asciifyReaction))
     ]
-    where
-      channel' = unChannel channel
+  where
+    channel' = unChannel channel
 
 nextStreamCommand :: Reaction Message a
 nextStreamCommand =
@@ -639,7 +642,7 @@ bot channel Started = do
   startRefreshHelpGistTimer $ builtinCommands channel
 -- TODO(#656): Restarted Twitch transport thread can duplicate timers
 bot name (Joined channel@(TwitchChannel _)) = do
-  startPeriodicCommands channel $ dispatchCommand name 
+  startPeriodicCommands channel $ dispatchCommand name
   periodicEffect (60 * 1000) (Just channel) (announceRunningPoll channel)
 -- TODO(#550): Periodic commands don't work in Discord channels
 bot _ (Joined channel@(DiscordChannel _)) =
@@ -669,7 +672,8 @@ messageReaction name =
 --   At the moment it may break a lot of commands that do not T.strip
 --   their input. In the scope of this issue we need to try to
 --   identify how many commands will be affected.q
-dispatchRedirect :: ChannelName -> Effect () -> Message (Command T.Text) -> Effect ()
+dispatchRedirect ::
+     ChannelName -> Effect () -> Message (Command T.Text) -> Effect ()
 dispatchRedirect name effect cmd = do
   effectOutput <-
     T.strip . T.concat . concatMap (\x -> [" ", x]) <$> listen effect
@@ -712,8 +716,8 @@ dispatchCommand channel message = do
 
 dispatchBuiltinCommand :: ChannelName -> Message (Command T.Text) -> Effect ()
 dispatchBuiltinCommand channel message@Message {messageContent = Command { commandName = name
-                                                                 , commandArgs = args
-                                                                 }} =
+                                                                         , commandArgs = args
+                                                                         }} =
   maybe
     (return ())
     (\bc -> runReaction (bcReaction bc) $ fmap (const args) message)

--- a/src/Bot.hs
+++ b/src/Bot.hs
@@ -480,6 +480,11 @@ builtinCommands =
               [ ( "help"
                 , subcommand
                     [("setgist", setHelpGistId), ("refresh", refreshHelpGistId)])
+              , ( "reply"
+                , subcommand
+                    [ ("link", setNoTrustLinkReplyCommand)
+                    , ("command", setNoTrustCommandReplyCommand)
+                    ])
               ]))
     , ( "version"
       , mkBuiltinCommand

--- a/src/Bot.hs
+++ b/src/Bot.hs
@@ -112,9 +112,7 @@ builtinCommands =
             cmapR (const ()) updateBttvEmotesCommand))
     , ( "help"
       , mkBuiltinCommand
-          ( "Send help"
-          , $githubLinkLocationStr
-          , helpCommand builtinCommands))
+          ("Send help", $githubLinkLocationStr, helpCommand builtinCommands))
     , ( "poll"
       , mkBuiltinCommand
           ( "Starts a poll. !poll <duration:secs> option1; option2; ...; option3"
@@ -226,15 +224,13 @@ builtinCommands =
           , authorizeSender senderAuthority $
             replyOnNothing "Only for mods" $
             regexArgs "([a-zA-Z0-9]+) ?(.*)" $
-            replyLeft $
-            pairArgs $ replyLeft $ addCustomCommand builtinCommands))
+            replyLeft $ pairArgs $ replyLeft $ addCustomCommand builtinCommands))
     , ( "delcmd"
       , mkBuiltinCommand
           ( "Delete custom command"
           , $githubLinkLocationStr
           , authorizeSender senderAuthority $
-            replyOnNothing "Only for mods" $
-            deleteCustomCommand builtinCommands))
+            replyOnNothing "Only for mods" $ deleteCustomCommand builtinCommands))
     , ( "updcmd"
       , mkBuiltinCommand
           ( "Update custom command"
@@ -406,9 +402,7 @@ builtinCommands =
       , mkBuiltinCommand
           ( "Suggest video for the friday stream"
           , $githubLinkLocationStr
-          , nonEmptyRoles
-              
-              fridayCommand))
+          , nonEmptyRoles fridayCommand))
     , ( "videoq"
       , mkBuiltinCommand
           ( "Get the link to the current Friday Queue"
@@ -631,7 +625,7 @@ mention =
 bot :: Bot
 bot Started = do
   startRefreshFridayGistTimer
-  startRefreshHelpGistTimer builtinCommands 
+  startRefreshHelpGistTimer builtinCommands
 -- TODO(#656): Restarted Twitch transport thread can duplicate timers
 bot (Joined channel@(TwitchChannel _)) = do
   startPeriodicCommands channel dispatchCommand

--- a/src/Bot.hs
+++ b/src/Bot.hs
@@ -190,7 +190,7 @@ builtinCommands channel =
             replyOnNothing "Not enough arguments" $
             cmapR (readMay . T.unpack) $
             replyOnNothing "Argument is not a number" $
-            addPeriodicTimerCommand $ dispatchCommand))
+            addPeriodicTimerCommand dispatchCommand))
     , ( "deltimer"
       , mkBuiltinCommand
           ( "Remove Periodic Timer"
@@ -642,7 +642,7 @@ bot channel Started = do
   startRefreshHelpGistTimer $ builtinCommands channel
 -- TODO(#656): Restarted Twitch transport thread can duplicate timers
 bot _ (Joined channel@(TwitchChannel _)) = do
-  startPeriodicCommands channel $ dispatchCommand
+  startPeriodicCommands channel dispatchCommand
   periodicEffect (60 * 1000) (Just channel) (announceRunningPoll channel)
 -- TODO(#550): Periodic commands don't work in Discord channels
 bot _ (Joined channel@(DiscordChannel _)) =
@@ -650,7 +650,7 @@ bot _ (Joined channel@(DiscordChannel _)) =
 bot _ (InMsg msg) =
   runReaction
     (dupLiftExtractR internalMessageRoles $
-     copyPastaFilter $ linkFilter $ messageReaction)
+     copyPastaFilter $ linkFilter messageReaction)
     msg
 
 messageReaction :: Reaction Message T.Text
@@ -665,7 +665,7 @@ messageReaction =
       [] -> runReaction mention msg
       pipe ->
         runReaction
-          (liftR (mapM redirectAlias) $ dispatchPipe)
+          (liftR (mapM redirectAlias) dispatchPipe)
           (Message sender mentioned pipe)
 
 -- TODO(#700): dispatchRedirect should add put a space between input and arguments
@@ -722,4 +722,4 @@ dispatchBuiltinCommand message@Message { messageSender = sender
   maybe
     (return ())
     (\bc -> runReaction (bcReaction bc) $ fmap (const args) message)
-    (M.lookup name $ builtinCommands $ channelToName $ senderChannel $ sender)
+    (M.lookup name $ builtinCommands $ channelToName $ senderChannel sender)

--- a/src/Bot/Links.hs
+++ b/src/Bot/Links.hs
@@ -135,15 +135,10 @@ linkFilter reaction =
   Reaction
     (\case
        Message { messageContent = message
-               , messageSender = sender@Sender { senderRoles = []
-                                               , senderChannel = channel
-                                               }
+               , messageSender = sender@Sender {senderRoles = []}
                }
          | textContainsLink message -> do
            timeoutSender 1 sender
-           replyToSender
-             sender
-             [qms|Links are not allowed for untrusted users.
-                  Subscribe to gain the trust instantly:
-                  https://twitch.tv/{unChannel $ channelToName channel}/subscribe|]
+           reply <- entityPayload <$> noTrustReply
+           replyToSender sender $ noTrustLinkReply reply
        msg -> runReaction reaction msg)

--- a/src/Bot/Links.hs
+++ b/src/Bot/Links.hs
@@ -130,8 +130,8 @@ internalMessageRoles msg = do
   messageSender' <- internalSenderRoles $ messageSender msg
   return $ msg {messageSender = messageSender'}
 
-linkFilter :: Reaction Message T.Text -> Reaction Message T.Text
-linkFilter reaction =
+linkFilter :: ChannelName -> Reaction Message T.Text -> Reaction Message T.Text
+linkFilter (ChannelName channel) reaction =
   Reaction
     (\case
        Message { messageContent = message
@@ -145,5 +145,5 @@ linkFilter reaction =
              sender
              [qms|Links are not allowed for untrusted users.
                   Subscribe to gain the trust instantly:
-                  https://twitch.tv/tsoding/subscribe|]
+                  https://twitch.tv/{channel}/subscribe|]
        msg -> runReaction reaction msg)

--- a/src/Bot/Links.hs
+++ b/src/Bot/Links.hs
@@ -130,13 +130,13 @@ internalMessageRoles msg = do
   messageSender' <- internalSenderRoles $ messageSender msg
   return $ msg {messageSender = messageSender'}
 
-linkFilter :: ChannelName -> Reaction Message T.Text -> Reaction Message T.Text
-linkFilter (ChannelName channel) reaction =
+linkFilter :: Reaction Message T.Text -> Reaction Message T.Text
+linkFilter reaction =
   Reaction
     (\case
        Message { messageContent = message
                , messageSender = sender@Sender { senderRoles = []
-                                               , senderChannel = TwitchChannel _
+                                               , senderChannel = TwitchChannel channel
                                                }
                }
          | textContainsLink message -> do

--- a/src/Bot/Links.hs
+++ b/src/Bot/Links.hs
@@ -136,7 +136,7 @@ linkFilter reaction =
     (\case
        Message { messageContent = message
                , messageSender = sender@Sender { senderRoles = []
-                                               , senderChannel = TwitchChannel channel
+                                               , senderChannel = channel
                                                }
                }
          | textContainsLink message -> do
@@ -145,5 +145,5 @@ linkFilter reaction =
              sender
              [qms|Links are not allowed for untrusted users.
                   Subscribe to gain the trust instantly:
-                  https://twitch.tv/{channel}/subscribe|]
+                  https://twitch.tv/{unChannel $ channelToName channel}/subscribe|]
        msg -> runReaction reaction msg)

--- a/src/Bot/Replies.hs
+++ b/src/Bot/Replies.hs
@@ -133,7 +133,7 @@ setNoTrustCommandReplyCommand =
 
 noTrustReply :: Effect (Entity NoTrustReply)
 noTrustReply = do
-  reply <- listToMaybe <$> selectEntities Proxy (Take 1 $ All)
+  reply <- listToMaybe <$> selectEntities Proxy (Take 1 All)
   case reply of
     Just reply' -> return reply'
     Nothing ->

--- a/src/Bot/Replies.hs
+++ b/src/Bot/Replies.hs
@@ -5,20 +5,20 @@ module Bot.Replies where
 
 import Data.Aeson
 import qualified Data.ByteString.Lazy as BS
+import Data.Functor
 import qualified Data.Map as M
+import Data.Maybe
+import Data.Proxy
 import qualified Data.Text as T
 import Effect
+import Entity
 import HyperNerd.Comonad
 import Network.HTTP.Simple (getResponseBody, parseRequest)
+import Property
 import Reaction
 import Regexp
 import Text.InterpolatedString.QM
 import Transport
-import Entity
-import Data.Proxy
-import Property
-import Data.Maybe
-import Data.Functor
 
 sayMessage :: Reaction Message T.Text
 sayMessage =

--- a/src/Bot/Replies.hs
+++ b/src/Bot/Replies.hs
@@ -79,13 +79,21 @@ onlyForRoles reply roles reaction =
 onlyForMods :: Reaction Message a -> Reaction Message a
 onlyForMods = onlyForRoles "Only for mods" authorityRoles
 
-nonEmptyRoles :: T.Text -> Reaction Message a -> Reaction Message a
-nonEmptyRoles reply reaction =
+nonEmptyRoles :: Reaction Message a -> Reaction Message a
+nonEmptyRoles reaction =
   transR duplicate $
   ifR
     (null . senderRoles . messageSender)
-    (cmapR (const reply) $ Reaction replyMessage)
+    (Reaction noTrust)
     (cmapR extract reaction)
+        
+noTrust :: Message a -> Effect ()
+noTrust msg = replyToSender (messageSender msg) reply
+  where
+      reply = [qms|You have to be trusted to use this command.
+                   Subscribe to gain the trust instantly:
+                   https://twitch.tv/{channel'}/subscribe|]
+      channel' = unChannel $ channelToName $ senderChannel $ messageSender msg
 
 onlyForTwitch :: Reaction Message a -> Reaction Message a
 onlyForTwitch reaction =

--- a/src/Bot/Replies.hs
+++ b/src/Bot/Replies.hs
@@ -86,14 +86,15 @@ nonEmptyRoles reaction =
     (null . senderRoles . messageSender)
     (Reaction noTrust)
     (cmapR extract reaction)
-        
+
 noTrust :: Message a -> Effect ()
 noTrust msg = replyToSender (messageSender msg) reply
   where
-      reply = [qms|You have to be trusted to use this command.
+    reply =
+      [qms|You have to be trusted to use this command.
                    Subscribe to gain the trust instantly:
                    https://twitch.tv/{channel'}/subscribe|]
-      channel' = unChannel $ channelToName $ senderChannel $ messageSender msg
+    channel' = unChannel $ channelToName $ senderChannel $ messageSender msg
 
 onlyForTwitch :: Reaction Message a -> Reaction Message a
 onlyForTwitch reaction =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,7 +12,6 @@ import Control.Concurrent.STM
 import Control.Monad
 import Data.Foldable
 import Data.Maybe
-import qualified Data.Text as T
 import System.Clock
 import System.Environment
 import Text.InterpolatedString.QM
@@ -35,12 +34,7 @@ eventLoop b prevCPUTime botState = do
 logicEntry :: BotState -> IO ()
 logicEntry botState = do
   currCPUTime <- getTime Monotonic
-  handleInEvent bot' Started botState >>= eventLoop bot' currCPUTime
-  where
-    channelName =
-      ChannelName $
-      maybe "tsoding" (T.drop 1 . tcChannel) $ configTwitch $ bsConfig botState
-    bot' = bot channelName
+  handleInEvent bot Started botState >>= eventLoop bot currCPUTime
 
 -- TODO(#399): supervisor is vulnerable to errors that happen at the start of the action
 supavisah :: Show a => IO a -> IO ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -18,6 +18,7 @@ import Text.InterpolatedString.QM
 import Transport
 import Transport.Discord
 import Transport.Twitch
+import qualified Data.Text as T
 
 eventLoop :: Bot -> TimeSpec -> BotState -> IO ()
 eventLoop b prevCPUTime botState = do
@@ -33,8 +34,12 @@ eventLoop b prevCPUTime botState = do
 
 logicEntry :: BotState -> IO ()
 logicEntry botState = do
+  print $ fmap tcChannel $ configTwitch $ bsConfig botState
   currCPUTime <- getTime Monotonic
-  handleInEvent bot Started botState >>= eventLoop bot currCPUTime
+  handleInEvent bot' Started botState >>= eventLoop bot' currCPUTime
+  where
+      channelName = ChannelName $ fromMaybe "tsoding" $ fmap (T.drop 1 . tcChannel) $ configTwitch $ bsConfig botState
+      bot' = bot channelName
 
 -- TODO(#399): supervisor is vulnerable to errors that happen at the start of the action
 supavisah :: Show a => IO a -> IO ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -34,7 +34,6 @@ eventLoop b prevCPUTime botState = do
 
 logicEntry :: BotState -> IO ()
 logicEntry botState = do
-  print $ fmap tcChannel $ configTwitch $ bsConfig botState
   currCPUTime <- getTime Monotonic
   handleInEvent bot' Started botState >>= eventLoop bot' currCPUTime
   where

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,13 +12,13 @@ import Control.Concurrent.STM
 import Control.Monad
 import Data.Foldable
 import Data.Maybe
+import qualified Data.Text as T
 import System.Clock
 import System.Environment
 import Text.InterpolatedString.QM
 import Transport
 import Transport.Discord
 import Transport.Twitch
-import qualified Data.Text as T
 
 eventLoop :: Bot -> TimeSpec -> BotState -> IO ()
 eventLoop b prevCPUTime botState = do
@@ -38,8 +38,10 @@ logicEntry botState = do
   currCPUTime <- getTime Monotonic
   handleInEvent bot' Started botState >>= eventLoop bot' currCPUTime
   where
-      channelName = ChannelName $ maybe "tsoding" (T.drop 1 . tcChannel) $ configTwitch $ bsConfig botState
-      bot' = bot channelName
+    channelName =
+      ChannelName $
+      maybe "tsoding" (T.drop 1 . tcChannel) $ configTwitch $ bsConfig botState
+    bot' = bot channelName
 
 -- TODO(#399): supervisor is vulnerable to errors that happen at the start of the action
 supavisah :: Show a => IO a -> IO ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -38,7 +38,7 @@ logicEntry botState = do
   currCPUTime <- getTime Monotonic
   handleInEvent bot' Started botState >>= eventLoop bot' currCPUTime
   where
-      channelName = ChannelName $ fromMaybe "tsoding" $ fmap (T.drop 1 . tcChannel) $ configTwitch $ bsConfig botState
+      channelName = ChannelName $ maybe "tsoding" (T.drop 1 . tcChannel) $ configTwitch $ bsConfig botState
       bot' = bot channelName
 
 -- TODO(#399): supervisor is vulnerable to errors that happen at the start of the action

--- a/src/Sqlite/EntityPersistence.hs
+++ b/src/Sqlite/EntityPersistence.hs
@@ -292,6 +292,16 @@ selectEntityIds conn name (Take n (Filter (PropertyEquals propertyName property)
     , ":propertyUTCTime" := (fromProperty property :: Maybe UTCTime)
     , ":n" := n
     ]
+selectEntityIds conn name (Take n All) =
+  map fromOnly <$>
+  queryNamed
+    conn
+    [r| SELECT entityId
+        FROM EntityProperty
+        WHERE entityName = :entityName
+        GROUP BY entityId
+        LIMIT :n |]
+    [":entityName" := name, ":n" := n]
 selectEntityIds conn name (Shuffle All) =
   map fromOnly <$>
   queryNamed

--- a/src/Transport.hs
+++ b/src/Transport.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Transport where
 
 import Control.Concurrent.STM

--- a/src/Transport.hs
+++ b/src/Transport.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
-
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Transport where
 
 import Control.Concurrent.STM
@@ -72,11 +73,12 @@ senderAuthority sender = any (`elem` senderRoles sender) authorityRoles
 
 channelToName :: Channel -> ChannelName
 channelToName (DiscordChannel x) = ChannelName $ T.pack $ show x
-channelToName (TwitchChannel x) = ChannelName x
+channelToName (TwitchChannel (T.uncons -> Just ('#', x))) = ChannelName x
+channelToName (TwitchChannel _) = ChannelName ""
 
 newtype ChannelName = ChannelName
   { unChannel :: T.Text
-  }
+  } deriving Eq
 
 data InEvent
   = Started

--- a/src/Transport.hs
+++ b/src/Transport.hs
@@ -71,15 +71,6 @@ paidRoles = [tsodingTwitchedDiscordRole, TwitchSub]
 senderAuthority :: Sender -> Bool
 senderAuthority sender = any (`elem` senderRoles sender) authorityRoles
 
-channelToName :: Channel -> ChannelName
-channelToName (DiscordChannel x) = ChannelName $ T.pack $ show x
-channelToName (TwitchChannel (T.uncons -> Just ('#', x))) = ChannelName x
-channelToName (TwitchChannel _) = ChannelName ""
-
-newtype ChannelName = ChannelName
-  { unChannel :: T.Text
-  } deriving Eq
-
 data InEvent
   = Started
   | Joined Channel

--- a/src/Transport.hs
+++ b/src/Transport.hs
@@ -70,6 +70,8 @@ paidRoles = [tsodingTwitchedDiscordRole, TwitchSub]
 senderAuthority :: Sender -> Bool
 senderAuthority sender = any (`elem` senderRoles sender) authorityRoles
 
+newtype ChannelName = ChannelName { unChannel:: T.Text }
+
 data InEvent
   = Started
   | Joined Channel

--- a/src/Transport.hs
+++ b/src/Transport.hs
@@ -70,6 +70,10 @@ paidRoles = [tsodingTwitchedDiscordRole, TwitchSub]
 senderAuthority :: Sender -> Bool
 senderAuthority sender = any (`elem` senderRoles sender) authorityRoles
 
+channelToName :: Channel -> ChannelName
+channelToName (DiscordChannel x) = ChannelName $ T.pack $ show x
+channelToName (TwitchChannel x) = ChannelName x
+
 newtype ChannelName = ChannelName
   { unChannel :: T.Text
   }

--- a/src/Transport.hs
+++ b/src/Transport.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Transport where
 

--- a/src/Transport.hs
+++ b/src/Transport.hs
@@ -70,7 +70,9 @@ paidRoles = [tsodingTwitchedDiscordRole, TwitchSub]
 senderAuthority :: Sender -> Bool
 senderAuthority sender = any (`elem` senderRoles sender) authorityRoles
 
-newtype ChannelName = ChannelName { unChannel:: T.Text }
+newtype ChannelName = ChannelName
+  { unChannel :: T.Text
+  }
 
 data InEvent
   = Started


### PR DESCRIPTION
Using HyperNerd often tells people to subscribe to tsoding too gain trust if they post links.
In my situation this isn't true however.

These changes will use the channel from the secretconfig rather than the hardcoded one, if none is available it defaults to tsoding anyway.