### PR TITLE
649 custom commands in help page

### DIFF
--- a/src/Bot/CustomCommand.hs
+++ b/src/Bot/CustomCommand.hs
@@ -8,6 +8,7 @@ module Bot.CustomCommand
   , updateCustomCommand
   , showCustomCommand
   , timesCustomCommand
+  , CustomCommand(..)
   ) where
 
 import Bot.Expr

--- a/src/Bot/CustomCommand.hs
+++ b/src/Bot/CustomCommand.hs
@@ -56,7 +56,7 @@ customCommandByName name =
   fmap listToMaybe $
   selectEntities Proxy $ Filter (PropertyEquals "name" $ PropertyText name) All
 
--- TODO: CRUD custom command should update help page now they're listed there as well.
+-- TODO(#815): CRUD custom command should update help page now they're listed there as well.
 addCustomCommand :: CommandTable -> Reaction Message (T.Text, T.Text)
 addCustomCommand builtinCommands =
   Reaction $ \Message {messageSender = sender, messageContent = (name, message)} -> do

--- a/src/Bot/CustomCommand.hs
+++ b/src/Bot/CustomCommand.hs
@@ -56,6 +56,7 @@ customCommandByName name =
   fmap listToMaybe $
   selectEntities Proxy $ Filter (PropertyEquals "name" $ PropertyText name) All
 
+-- TODO: Add custom command should update help page now they're listed there as well.
 addCustomCommand :: CommandTable -> Reaction Message (T.Text, T.Text)
 addCustomCommand builtinCommands =
   Reaction $ \Message {messageSender = sender, messageContent = (name, message)} -> do

--- a/src/Bot/CustomCommand.hs
+++ b/src/Bot/CustomCommand.hs
@@ -56,7 +56,7 @@ customCommandByName name =
   fmap listToMaybe $
   selectEntities Proxy $ Filter (PropertyEquals "name" $ PropertyText name) All
 
--- TODO: Add custom command should update help page now they're listed there as well.
+-- TODO: CRUD custom command should update help page now they're listed there as well.
 addCustomCommand :: CommandTable -> Reaction Message (T.Text, T.Text)
 addCustomCommand builtinCommands =
   Reaction $ \Message {messageSender = sender, messageContent = (name, message)} -> do

--- a/src/Bot/Help.hs
+++ b/src/Bot/Help.hs
@@ -25,11 +25,10 @@ import Reaction
 import Text.InterpolatedString.QM
 import Transport
 
-data HelpState =
-  HelpState
-    { helpStateGistId :: Maybe GistId
-    , helpStateGistFresh :: Bool
-    }
+data HelpState = HelpState
+  { helpStateGistId :: Maybe GistId
+  , helpStateGistFresh :: Bool
+  }
 
 updateHelpStateGistId :: GistId -> HelpState -> HelpState
 updateHelpStateGistId (GistId "") state = state {helpStateGistId = Nothing}

--- a/src/Bot/Help.hs
+++ b/src/Bot/Help.hs
@@ -74,15 +74,25 @@ refreshHelpGistId =
 
 gistRenderCommandTable :: CommandTable -> T.Text
 gistRenderCommandTable =
-  ("* Builtin Commands \n" <>) . T.unlines . map renderRow . M.toList
+  ([qms|* Builtin Commands\n{header}\n|-\n|] <>) .
+  T.unlines . map renderRow . M.toList
   where
+    header :: T.Text
+    header = "|Name|Description|Location|"
+    renderRow :: (T.Text, BuiltinCommand) -> T.Text
     renderRow (name, command) =
-      [qms||{name}|{bcDescription command}|{bcGitHubLocation command}||]
+      [qms||{name}|{bcDescription command}|{location}||]
+      where
+        location :: T.Text
+        location = [qms|[[{bcGitHubLocation command}][Source↗]]|]
 
 gistRenderCustomCommandsTable :: [Entity CustomCommand] -> T.Text
 gistRenderCustomCommandsTable =
-  ("* Custom commands \n" <>) . T.unlines . map (renderRow . entityPayload)
+  ([qms|* Custom commands\n{header}\n|-\n|] <>) .
+  T.unlines . map (renderRow . entityPayload)
   where
+    header :: T.Text
+    header = "|Name|Definition|%times|"
     renderRow (CustomCommand name message times) =
       [qms||{name}|{message}|{times}||]
 


### PR DESCRIPTION
This change adds the custom commands to the help page.
There is a TODO to make them automatically updated on change because I want to keep the PR smaller.

#649 